### PR TITLE
feat: Added the CC and BCC headers support. Enabled strict mode accor…

### DIFF
--- a/src/Api/Email.php
+++ b/src/Api/Email.php
@@ -59,6 +59,18 @@ class Email
           Assert::email($item['email'], 'Recipient should be an array with "email" key containing a valid email address.. Got: %s');
       }
 
+      // Add the CC and BCC headers support.
+      if (isset($headers['CC'])) {
+        Assert::email($headers['CC'], 'The CC header must be an email. Got: %s');
+      }
+      if (isset($headers['BCC'])) {
+        Assert::email($headers['BCC'], 'The BCC header must be an email. Got: %s');
+      }
+      // Enable strict mode according to https://docs.unione.io/en/cc-and-bcc .
+      if (isset($headers['CC']) || isset($headers['BCC'])) {
+        $headers['X-UNIONE'] = 'strict=true';
+      }
+
       return $this->client->httpRequest('email/send.json', ['message' => $params], $headers);
   }
 

--- a/src/Api/Email.php
+++ b/src/Api/Email.php
@@ -11,7 +11,8 @@ use Webmozart\Assert\Assert;
 /**
  *  This class for sending  Mail.
  */
-class Email {
+class Email
+{
     /**
      * The UnioneClient client.
      *
@@ -22,7 +23,8 @@ class Email {
     /**
      * @param UnioneClient $client
      */
-    public function __construct(UnioneClient $client) {
+    public function __construct(UnioneClient $client)
+    {
         $this->client = $client;
     }
 
@@ -40,7 +42,8 @@ class Email {
    * @throws GuzzleException
    * @see  https://docs.unione.io/en/web-api-ref#email-send
    */
-  public function send(array $params, array $headers = []): array {
+  public function send(array $params, array $headers = []): array
+  {
       if (!empty($params['message'])) {
           $params = $params['message'];
       }
@@ -83,7 +86,8 @@ class Email {
    * @throws GuzzleException
    * @see https://docs.unione.io/en/web-api-ref#email-subscribe
    */
-  public function subscribe(array $params): array {
+  public function subscribe(array $params): array
+  {
       Assert::email($params['from_email'], 'The from_email must be an email. Got: %s');
       Assert::string($params['from_name'], 'The from_name must be a string. Got: %s');
       Assert::email($params['to_email'], 'The to_email must be an email. Got: %s');

--- a/src/Api/Email.php
+++ b/src/Api/Email.php
@@ -11,8 +11,7 @@ use Webmozart\Assert\Assert;
 /**
  *  This class for sending  Mail.
  */
-class Email
-{
+class Email {
     /**
      * The UnioneClient client.
      *
@@ -23,8 +22,7 @@ class Email
     /**
      * @param UnioneClient $client
      */
-    public function __construct(UnioneClient $client)
-    {
+    public function __construct(UnioneClient $client) {
         $this->client = $client;
     }
 
@@ -42,8 +40,7 @@ class Email
    * @throws GuzzleException
    * @see  https://docs.unione.io/en/web-api-ref#email-send
    */
-  public function send(array $params, array $headers = []): array
-  {
+  public function send(array $params, array $headers = []): array {
       if (!empty($params['message'])) {
           $params = $params['message'];
       }
@@ -86,8 +83,7 @@ class Email
    * @throws GuzzleException
    * @see https://docs.unione.io/en/web-api-ref#email-subscribe
    */
-  public function subscribe(array $params): array
-  {
+  public function subscribe(array $params): array {
       Assert::email($params['from_email'], 'The from_email must be an email. Got: %s');
       Assert::string($params['from_name'], 'The from_name must be a string. Got: %s');
       Assert::email($params['to_email'], 'The to_email must be an email. Got: %s');

--- a/src/Api/Email.php
+++ b/src/Api/Email.php
@@ -47,7 +47,7 @@ class Email
       $headers_to_normalise = ['to', 'cc', 'bcc'];
       foreach ($headers as $key => $header) {
         $test = \strtolower($key);
-        if (\in_array($test, $headers_to_normalise)) {
+        if (\in_array($test, $headers_to_normalise, TRUE)) {
           if ($test !== $key) {
             $headers[$test] = $headers[$key];
             unset($headers[$key]);

--- a/src/Api/Email.php
+++ b/src/Api/Email.php
@@ -46,8 +46,8 @@ class Email
   {
       $headers_to_normalise = ['to', 'cc', 'bcc'];
       foreach ($headers as $key => $header) {
-        $test = strtolower($key);
-        if (in_array($test, $headers_to_normalise)) {
+        $test = \strtolower($key);
+        if (\in_array($test, $headers_to_normalise)) {
           if ($test !== $key) {
             $headers[$test] = $headers[$key];
             unset($headers[$key]);
@@ -57,19 +57,20 @@ class Email
 
       $recipients = [];
       // Prepare to remove duplicates if any.
-      if (is_array($params['recipients'])) {
+      if (\is_array($params['recipients'])) {
         foreach ($params['recipients'] as $item) {
           $recipients[$item['email']] = $item;
         }
       }
       foreach ($headers_to_normalise as $key) {
         if (isset($headers[$key])) {
-          foreach (explode(',', $headers[$key]) as $item) {
-            $recipients[trim($item)] = ['email' => trim($item)];
+          foreach (\explode(',', $headers[$key]) as $item) {
+            $trimmed = \trim($item);
+            $recipients[$trimmed] = ['email' => $trimmed];
           }
         }
       }
-      $params['recipients'] = array_values($recipients);
+      $params['recipients'] = \array_values($recipients);
 
       if (!empty($params['message'])) {
           $params = $params['message'];

--- a/src/UnioneClient.php
+++ b/src/UnioneClient.php
@@ -19,7 +19,7 @@ final class UnioneClient
     /**
      * The current version of the SDK.
      */
-    private const VERSION = '1.2.0';
+    private const VERSION = '1.3.0';
 
     /**
      * The HTTP client.


### PR DESCRIPTION
…ding to https://docs.unione.io/en/cc-and-bcc if headers CC or BCC are present. Added emails from 'CC' and 'BCC' headers to the 'recipients' array with substitutions and filtered them by email address to remove duplicates. Checked and moved headers 'TO', 'CC', 'BCC' to the lowercase if they are present in the other variants. Added the checking if it contains email for the 'TO' header, fixed checking for 'CC' and 'BCC' headers.